### PR TITLE
Update depth of serialization for input variables

### DIFF
--- a/PSGraphQL/Functions/Invoke-GraphQLQuery.ps1
+++ b/PSGraphQL/Functions/Invoke-GraphQLQuery.ps1
@@ -206,7 +206,7 @@ function Invoke-GraphQLQuery {
         # Serialize $jsonRequestObject:
         [string]$jsonRequestBody = ""
         try {
-            $jsonRequestBody = $jsonRequestObject | ConvertTo-Json -Compress -ErrorAction Stop
+            $jsonRequestBody = $jsonRequestObject | ConvertTo-Json -Depth 4 -Compress -ErrorAction Stop
         }
         catch {
             Write-Error -Exception $_.Exception -ErrorAction Stop


### PR DESCRIPTION
When passing in a hastable of variable that contains a complex object the nested objects are not correctly serialized but are displayed as a string of the type name

e.g.
```
{"variables":{"patches":["System.Collections.Hashtable"]},", "query": /** SNIP **/}
```