### PR TITLE
Update Compress-String to alolow different line endings

### DIFF
--- a/PSGraphQL/PrivateFunctions/Compress-String.ps1
+++ b/PSGraphQL/PrivateFunctions/Compress-String.ps1
@@ -1,5 +1,5 @@
 # Compresses and trims GraphQL operations for processing by this module's functions:
 function Compress-String([string]$InputString) {
-    $output = ([String]::Join(" ",($InputString.Split("`n")))).Trim()
+    $output = ($InputString -replace "`r`n|`n", " ").Trim()
     return $output
 }


### PR DESCRIPTION
I was facing issues when using this in Windows, the payload that gets sent ends up with `\r` in the string, which the upstream system did not like.

Current function, if the line ending for the system (mainly windows) is `\r\n`, it will leave the `\r`, this update will remove either `\n` or `\r\n`